### PR TITLE
Expose the filename as a public non-inlinable constant

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/uniqueid/IdStore.java
+++ b/src/main/java/org/jenkinsci/plugins/uniqueid/IdStore.java
@@ -1,16 +1,14 @@
 package org.jenkinsci.plugins.uniqueid;
 
 import hudson.ExtensionPoint;
-
 import jenkins.model.Jenkins;
+import org.apache.commons.codec.binary.Base64;
 
-import java.io.UnsupportedEncodingException;
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.nio.charset.StandardCharsets;
 import java.util.UUID;
-
-import javax.annotation.Nullable;
-
-import org.apache.commons.codec.binary.Base64;
 
 /**
  * An abstraction to persistently store and retrieve unique id's
@@ -44,7 +42,7 @@ public abstract class IdStore<T> implements ExtensionPoint {
 
     /**
      * Get the id for this given object.
-     * @param object
+     * @param object the object.
      * @return the id or {@code null} if none assigned.
      */
     @Nullable
@@ -55,10 +53,10 @@ public abstract class IdStore<T> implements ExtensionPoint {
     }
 
     /**
-     * Retrieve an {@link IdStore} for the given type
-     * @param clazz
-     * @param <C>
-     * @return the store which supports the type, or null if none
+     * Retrieve an {@link IdStore} for the given type.
+     * @param clazz the type of object.
+     * @param <C> the type of object.
+     * @return the store which supports the type, or {@code null} if none.
      */
     @Nullable
     public static <C> IdStore<C> forClass(Class<C> clazz) {
@@ -96,6 +94,17 @@ public abstract class IdStore<T> implements ExtensionPoint {
         } else {
             return store.get(object);
         }
+    }
+
+    /**
+     * Returns the generic filename that a store should use for storing the unique id.
+     *
+     * @return the generic filename.
+     * @since 2.1.0
+     */
+    @Nonnull
+    public static String fileName() {
+        return "unique-id.txt";
     }
 
     /**

--- a/src/main/java/org/jenkinsci/plugins/uniqueid/implv2/PersistenceRootIdStore.java
+++ b/src/main/java/org/jenkinsci/plugins/uniqueid/implv2/PersistenceRootIdStore.java
@@ -28,16 +28,13 @@ public class PersistenceRootIdStore extends IdStore<PersistenceRoot> {
     /** Our Logger. */
     private final static Logger LOGGER = Logger.getLogger(PersistenceRootIdStore.class.getName());
 
-    /** The name of the file in which we store the unique ID. */
-    private final static String ID_FILE = "unique-id.txt";
-
     public PersistenceRootIdStore() {
         super(PersistenceRoot.class);
     }
 
     @Override
     public void make(PersistenceRoot object) {
-        File f = new File(object.getRootDir(), ID_FILE);
+        File f = new File(object.getRootDir(), IdStore.fileName());
         if (!f.exists()) {
             File tmp = null;
             try {
@@ -59,7 +56,7 @@ public class PersistenceRootIdStore extends IdStore<PersistenceRoot> {
 
     @Override
     public String get(PersistenceRoot object) {
-        File f = new File(object.getRootDir(), ID_FILE);
+        File f = new File(object.getRootDir(), IdStore.fileName());
         if (f.exists() && f.canRead()) {
             try {
                 String str = FileUtils.readFileToString(f, StandardCharsets.UTF_8);
@@ -79,7 +76,7 @@ public class PersistenceRootIdStore extends IdStore<PersistenceRoot> {
 
     @Restricted(NoExternalUse.class)
     public static void create(PersistenceRoot object, String uniqueId) throws IOException {
-        File f = new File(object.getRootDir(), ID_FILE);
+        File f = new File(object.getRootDir(), IdStore.fileName());
         if (!f.exists()) {
             LOGGER.log(Level.FINE, "Creating file ({1}) to store ID for ({0}) whose RootDir is ({2}).", new Object[] {object.toString(), f, object.getRootDir()});
             // no need to migrate if its there to begin with!

--- a/src/main/java/org/jenkinsci/plugins/uniqueid/implv2/PersistenceRootIdStore.java
+++ b/src/main/java/org/jenkinsci/plugins/uniqueid/implv2/PersistenceRootIdStore.java
@@ -14,6 +14,8 @@ import java.util.logging.Logger;
 
 import org.apache.commons.io.FileUtils;
 import org.jenkinsci.plugins.uniqueid.IdStore;
+import org.jenkinsci.plugins.uniqueid.impl.FolderIdStore;
+import org.jenkinsci.plugins.uniqueid.impl.JobIdStore;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 


### PR DESCRIPTION
- Needs to come via a static method in case we ever need to change it so that dependencies using it do not have to be recompiled

@reviewbybees